### PR TITLE
chore(package): add publishconfig to enable public access

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,5 +68,8 @@
 		"rollup-plugin-generate-package-json": "^3.2.0",
 		"semantic-release": "^24.2.3",
 		"typescript": "^5.8.2"
+	},
+	"publishConfig": {
+		"access": "public"
 	}
 }


### PR DESCRIPTION
### **User description**
Added publishConfig setting with public access flag to package.json. This ensures the package will be publicly accessible when published to npm rather than private by default.


___

### **PR Type**
enhancement


___

### **Description**
- Added `publishConfig` to `package.json` for public access.

- Ensures package is publicly accessible on npm by default.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add `publishConfig` for public npm access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

<li>Added <code>publishConfig</code> section with <code>access: public</code>.<br> <li> Ensures the package is published as public by default.


</details>


  </td>
  <td><a href="https://github.com/ElsiKora/X-Captcha-Client/pull/2/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>